### PR TITLE
フレーム抽出と画面判定を統合して不要フレームの保存を排除する

### DIFF
--- a/src/processing/screen_detector.py
+++ b/src/processing/screen_detector.py
@@ -1,7 +1,21 @@
+import os
 import cv2
 import pandas as pd
 from tqdm import tqdm
 from src.screen.classifier import ScreenClassifier
+from src.util.io import ensure_dir
+
+
+def save_screen_log(log_rows, results_dir):
+    """
+    画面判定結果をCSVファイルに保存する。
+    統合フロー・従来フローどちらからも呼び出せる独立関数。
+    """
+    ensure_dir(results_dir)
+    log_path = os.path.join(results_dir, "screen_log.csv")
+    pd.DataFrame(log_rows).to_csv(log_path, index=False, encoding="utf-8-sig")
+    print(f"画面判定結果を {log_path} に保存しました。")
+
 
 class ScreenDetector:
     """
@@ -33,17 +47,5 @@ class ScreenDetector:
                 prev_type = screen_type
 
         # 画面判定ログをCSVに保存
-        self._save_screen_log(log_rows, results_dir)
+        save_screen_log(log_rows, results_dir)
         return screens, match_count
-    
-    def _save_screen_log(self, log_rows, results_dir):
-        """
-        画面判定結果をCSVファイルに保存する。
-        """
-        import os
-        from src.util.io import ensure_dir
-        
-        ensure_dir(results_dir)
-        log_path = os.path.join(results_dir, "screen_log.csv")
-        pd.DataFrame(log_rows).to_csv(log_path, index=False, encoding="utf-8-sig")
-        print(f"画面判定結果を {log_path} に保存しました。")


### PR DESCRIPTION
## Summary
- フレーム抽出と画面判定を1パスで実行する `extract_and_classify_frames()` を追加
- matching/result フレームのみディスクに保存し、不要フレーム（80-90%）の書き込みを排除
- 画面判定ログ出力を独立関数 `save_screen_log()` に抽出
- パイプラインで統合フロー `_extract_and_classify_with_cache()` を使用するように更新
- 既存キャッシュ・既存メソッドとの互換性を維持

## Test plan
- [ ] 動画ファイルで `python main.py --input <動画> --config config/config.yaml` を実行し正常終了を確認
- [ ] `output/frames/` 配下に matching/result フレームしか保存されていないことを確認
- [ ] 既存の screens_cache がある場合にキャッシュが正しく使われることを確認
- [ ] `--mode timestamps` でも正常に動作することを確認

Closes #4