### PR TITLE
フレーム読み取りを grab/retrieve 方式に変更して不要デコードをスキップする

### DIFF
--- a/src/video/handler.py
+++ b/src/video/handler.py
@@ -71,8 +71,6 @@ def extract_and_classify_frames(video_path, frame_interval_sec, output_dir, conf
     cap = open_video(video_path)
     fps = get_fps(cap)
     frame_interval = int(fps * frame_interval_sec)
-    frame_count = 0
-    idx = 0
 
     screens = []
     match_count = 0
@@ -83,11 +81,16 @@ def extract_and_classify_frames(video_path, frame_interval_sec, output_dir, conf
     total_extracted = total_frames // frame_interval
     pbar = tqdm(total=total_extracted, desc="フレーム抽出・画面判定")
 
+    frame_count = 0
+    idx = 0
     while True:
-        ret, frame = cap.read()
-        if not ret:
+        if not cap.grab():
             break
         if frame_count % frame_interval == 0:
+            ret, frame = cap.retrieve()
+            if not ret:
+                break
+
             screen_type = classifier.classify(frame)
             frame_path = os.path.join(output_dir, f"frame_{idx:05d}.png")
             log_rows.append({"frame": f"frame_{idx:05d}.png", "screen_type": screen_type})


### PR DESCRIPTION
## Summary
- `extract_and_classify_frames()` のフレーム読み取りを `cap.read()` から `cap.grab()` / `cap.retrieve()` に変更
- 不要フレームはデコードせず `grab()` で位置だけ進め、対象フレームのみ `retrieve()` でデコード

## Test plan
- [ ] `python main.py --input <動画> --config config/config.yaml --mode timestamps` で正常動作を確認
- [ ] 従来と同じタイムスタンプ結果が出力されることを確認
- [ ] 処理時間が短縮されていることを確認

Closes #6