### PR TITLE
fix: YouTube bot 検出回避（クッキー対応・Node.js ランタイム指定）

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -36,11 +36,21 @@ jobs:
         run: pip install yt-dlp
 
       - name: 動画をダウンロード
+        env:
+          YOUTUBE_COOKIES: ${{ secrets.YOUTUBE_COOKIES }}
         run: |
+          if [ -n "$YOUTUBE_COOKIES" ]; then
+            echo "$YOUTUBE_COOKIES" > cookies.txt
+            COOKIES_OPT="--cookies cookies.txt"
+          else
+            COOKIES_OPT=""
+          fi
           yt-dlp \
             -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" \
             --merge-output-format mp4 \
+            --js-runtimes nodejs \
             -o "broadcast.mp4" \
+            $COOKIES_OPT \
             "${{ inputs.broadcast_url }}"
 
       - name: 解析を実行


### PR DESCRIPTION
## Summary

- GitHub Actions の IP が YouTube に bot 判定される問題を修正
- `YOUTUBE_COOKIES` シークレット（任意）をクッキーファイルとして渡せるように対応
- `--js-runtimes nodejs` を追加（ubuntu-latest に Node.js がプリインストール済み）
- クッキー未設定時はそのままダウンロードを試みる（後方互換）

## Test plan

- [ ] `YOUTUBE_COOKIES` シークレットを登録してワークフローを再実行し、ダウンロードが成功することを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)