### PR TITLE
fix: yt-dlp JS ランタイム名の typo 修正（nodejs → node）

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -48,7 +48,7 @@ jobs:
           yt-dlp \
             -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" \
             --merge-output-format mp4 \
-            --js-runtimes nodejs \
+            --js-runtimes node \
             -o "broadcast.mp4" \
             $COOKIES_OPT \
             "${{ inputs.broadcast_url }}"


### PR DESCRIPTION
## Summary

- `--js-runtimes nodejs` を `--js-runtimes node` に修正（yt-dlp が認識する正しい名前）
- この typo により n-challenge が解けず動画フォーマットが取得できなかった

## Test plan

- [ ] ワークフローを再実行し、yt-dlp が動画のダウンロードに成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)