### PR TITLE
fix: yt-dlp n-challenge 解決スクリプトのリモート取得を有効化

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -49,6 +49,7 @@ jobs:
             -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" \
             --merge-output-format mp4 \
             --js-runtimes node \
+            --remote-components ejs:github \
             -o "broadcast.mp4" \
             $COOKIES_OPT \
             "${{ inputs.broadcast_url }}"


### PR DESCRIPTION
## Summary

- `--remote-components ejs:github` を追加
- yt-dlp は n-challenge の解決に外部スクリプト（EJS）が必要で、これを GitHub からダウンロードする設定が抜けていた
- これがないと動画フォーマットが取得できず `Requested format is not available` エラーになる

## Test plan

- [ ] ワークフローを再実行し、yt-dlp が動画のダウンロードに成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)