### PR TITLE
fix: ダウンロードファイル名の動的検出とデバッグログ追加

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -36,6 +36,7 @@ jobs:
         run: pip install yt-dlp
 
       - name: 動画をダウンロード
+        id: download
         env:
           YOUTUBE_COOKIES: ${{ secrets.YOUTUBE_COOKIES }}
         run: |
@@ -50,12 +51,19 @@ jobs:
             --merge-output-format mp4 \
             --js-runtimes node \
             --remote-components ejs:github \
-            -o "broadcast.mp4" \
+            -o "broadcast.%(ext)s" \
             $COOKIES_OPT \
             "${{ inputs.broadcast_url }}"
+          VIDEO_FILE=$(ls broadcast.* | head -1)
+          echo "=== ダウンロードされたファイル ==="
+          ls -lh broadcast.*
+          echo "video_file=$VIDEO_FILE" >> $GITHUB_OUTPUT
 
       - name: 解析を実行
-        run: python main.py --input broadcast.mp4 --mode timestamps
+        run: |
+          VIDEO_FILE="${{ steps.download.outputs.video_file }}"
+          echo "解析対象ファイル: $VIDEO_FILE ($(du -h "$VIDEO_FILE" | cut -f1))"
+          python main.py --input "$VIDEO_FILE" --mode timestamps
 
       - name: タイムスタンプを確認
         run: |


### PR DESCRIPTION
## Summary

- `-o "broadcast.mp4"` を `-o "broadcast.%(ext)s"` に変更し、yt-dlp が実際に出力したファイル名を動的に検出するように修正
- ダウンロード後に `ls -lh broadcast.*` でファイルを表示してデバッグを容易に
- 解析ステップでもファイル名とサイズをログ出力して `cv2.VideoCapture` 失敗時の原因特定を支援

## 背景

`cv2.VideoCapture` が開けない場合と、ファイルが存在しない場合で同じ `FileNotFoundError` が投げられるため、まずファイルが正しく存在しているかをログで確認できるようにした

## Test plan

- [ ] ワークフローを実行し、ダウンロードステップで `broadcast.*` のファイル名とサイズが表示されることを確認
- [ ] 解析ステップで「解析対象ファイル: ...」が表示され、正常に解析が進むことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)