### PR TITLE
fix: CSV の BOM を考慮した utf-8-sig エンコーディングで読み込む

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -75,7 +75,7 @@ jobs:
               print("ERROR: タイムスタンプ CSV が見つかりません")
               sys.exit(1)
 
-          with open(csv_files[0]) as f:
+          with open(csv_files[0], encoding="utf-8-sig") as f:
               rows = list(csv.DictReader(f))
 
           print(f"=== {len(rows)} 試合を検出 ===")
@@ -97,7 +97,7 @@ jobs:
           event_id = os.environ.get("EVENT_ID", "")
 
           csv_files = glob.glob("output/results/timestamps_*.csv")
-          with open(csv_files[0]) as f:
+          with open(csv_files[0], encoding="utf-8-sig") as f:
               rows = list(csv.DictReader(f))
 
           # HH:MM:SS → H:MM:SS 変換（API の期待フォーマット）


### PR DESCRIPTION
## Summary

- タイムスタンプ CSV の読み込みを `encoding="utf-8-sig"` に変更
- `save_dataframe_csv` が `utf-8-sig`（BOM付きUTF-8）で保存するため、デフォルトエンコーディングで読むと最初のカラム名が `\ufeffmatch_number` になり `KeyError` が発生していた

## 影響箇所

- 「タイムスタンプを確認」ステップ
- 「vsmobile-kgy API にタイムスタンプを送信」ステップ

## Test plan

- [ ] ワークフローを再実行し、「=== N 試合を検出 ===」の後にエラーなくタイムスタンプが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)