### PR TITLE
fix: 中間ファイルを誤検出しないよう broadcast.mp4 を明示的にチェック

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -51,13 +51,16 @@ jobs:
             --merge-output-format mp4 \
             --js-runtimes node \
             --remote-components ejs:github \
-            -o "broadcast.%(ext)s" \
+            -o "broadcast.mp4" \
             $COOKIES_OPT \
             "${{ inputs.broadcast_url }}"
-          VIDEO_FILE=$(ls broadcast.* | head -1)
           echo "=== ダウンロードされたファイル ==="
           ls -lh broadcast.*
-          echo "video_file=$VIDEO_FILE" >> $GITHUB_OUTPUT
+          if [ ! -f "broadcast.mp4" ]; then
+            echo "ERROR: broadcast.mp4 が見つかりません"
+            exit 1
+          fi
+          echo "video_file=broadcast.mp4" >> $GITHUB_OUTPUT
 
       - name: 解析を実行
         run: |


### PR DESCRIPTION
## Summary

- `-o "broadcast.%(ext)s"` を `-o "broadcast.mp4"` に戻し、マージ後のファイル名を固定
- `ls broadcast.* | head -1` をやめ、`broadcast.mp4` の存在を明示的に確認するように変更
- `ls -lh broadcast.*` は残してデバッグ用ログとして活用

## 原因

yt-dlp が映像・音声を別ストリームでダウンロードしてマージする際、中間ファイル（`broadcast.f140.m4a` 等）が残ることがある。`ls broadcast.* | head -1` はアルファベット順で `f140.m4a` を `mp4` より先に拾ってしまい、音声ファイルを動画として解析しようとしてエラーになっていた。

## Test plan

- [ ] 本番動画（8時間）で再実行し、`broadcast.mp4` が正しく検出されて解析が完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)