### PR TITLE
fix: 音声なし映像のみDLでディスク不足によるマージ失敗を解消

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -47,7 +47,7 @@ jobs:
             COOKIES_OPT=""
           fi
           yt-dlp \
-            -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" \
+            -f "bestvideo[ext=mp4]/bestvideo" \
             --merge-output-format mp4 \
             --js-runtimes node \
             --remote-components ejs:github \


### PR DESCRIPTION
## Summary

- フォーマット指定を `bestvideo[ext=mp4]+bestaudio[ext=m4a]/...` → `bestvideo[ext=mp4]/bestvideo` に変更
- 映像のみDLすることでマージが不要になり、ディスク使用量を約半分に削減

## 原因

8時間動画（映像16GB + 音声441MB）のマージ時に合計32GB超のディスクが必要となり、GitHub Actions ランナーのディスク容量を超えてマージが失敗していた。
フレーム解析は視覚判定のみのため音声は不要。

## Test plan

- [ ] 本番動画（8時間）で再実行し、`broadcast.mp4` が正しく検出されて解析が完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)