### PR TITLE
perf: ダウンロード解像度を 720p に制限してファイルサイズと処理時間を削減

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -47,7 +47,7 @@ jobs:
             COOKIES_OPT=""
           fi
           yt-dlp \
-            -f "bestvideo[ext=mp4]/bestvideo" \
+            -f "bestvideo[height<=720][ext=mp4]/bestvideo[height<=720]/bestvideo[ext=mp4]/bestvideo" \
             --merge-output-format mp4 \
             --js-runtimes node \
             --remote-components ejs:github \


### PR DESCRIPTION
## Summary

- フォーマット指定を `bestvideo[height<=720][ext=mp4]/bestvideo[height<=720]/bestvideo[ext=mp4]/bestvideo` に変更
- 16GB → 約 2〜4GB に削減し、ダウンロード時間およびフレーム読み込み時間を大幅短縮

## 精度への影響

ROI 座標がすべて割合指定（0.0〜1.0）のため、解像度変更による精度への影響なし

## フォーマット選択の優先順位

1. `bestvideo[height<=720][ext=mp4]` — 720p 以下の mp4（最優先）
2. `bestvideo[height<=720]` — 720p 以下の任意フォーマット
3. `bestvideo[ext=mp4]` — mp4 のベスト画質（720p が存在しない場合）
4. `bestvideo` — 任意フォーマットのベスト画質（最終フォールバック）

## Test plan

- [ ] 本番動画（8時間）で再実行し、ダウンロードファイルサイズが削減されて処理時間が短縮されることを確認
- [ ] タイムスタンプの検出精度に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)