### PR TITLE
perf: ダウンロード解像度の上限を 720p から 480p に変更

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -47,7 +47,7 @@ jobs:
             COOKIES_OPT=""
           fi
           yt-dlp \
-            -f "bestvideo[height<=720][ext=mp4]/bestvideo[height<=720]/bestvideo[ext=mp4]/bestvideo" \
+            -f "bestvideo[height<=480][ext=mp4]/bestvideo[height<=480]/bestvideo[ext=mp4]/bestvideo" \
             --merge-output-format mp4 \
             --js-runtimes node \
             --remote-components ejs:github \


### PR DESCRIPTION
## Summary

- フォーマット指定の `height<=720` を `height<=480` に変更
- 9.5GB（720p）→ 約 4〜5GB（480p）への削減を期待

## 精度への影響なしの根拠

- ROI 座標が割合指定のため解像度非依存
- `resize_to_template` で ROI 領域をテンプレートサイズにリサイズしてからマッチングするため解像度に依存しない
- `timestamps` モードは OCR を使用しないため OCR 精度も無関係

## Test plan

- [ ] 本番動画（8時間）で再実行し、ファイルサイズが 720p 時より削減されることを確認
- [ ] タイムスタンプの検出結果が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)