### PR TITLE
CLIをタイムスタンプ抽出をメイン・OCR解析をオプションとした構成に変更

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           VIDEO_FILE="${{ steps.download.outputs.video_file }}"
           echo "解析対象ファイル: $VIDEO_FILE ($(du -h "$VIDEO_FILE" | cut -f1))"
-          python main.py --input "$VIDEO_FILE" --mode timestamps
+          python main.py --input "$VIDEO_FILE"
 
       - name: タイムスタンプを確認
         run: |

--- a/main.py
+++ b/main.py
@@ -8,11 +8,11 @@ def main():
     parser = argparse.ArgumentParser(description="EXVS2IB 戦績トラッカー")
     parser.add_argument("--input", required=True, help="入力動画ファイルのパス")
     parser.add_argument("--config", default="config/config.yaml", help="設定ファイルのパス")
-    parser.add_argument("--mode", choices=["full", "timestamps"], default="full",
-                        help="実行モード: full=全工程実行（デフォルト）, timestamps=試合開始タイムスタンプのみ出力")
+    parser.add_argument("--with-ocr", action="store_true",
+                        help="【実験的】プレイヤー名・機体名・勝敗も抽出する（精度は保証されない）")
     args = parser.parse_args()
 
-    pipeline = Pipeline(args.input, args.config, mode=args.mode)
+    pipeline = Pipeline(args.input, args.config, with_ocr=args.with_ocr)
     pipeline.run_pipeline()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `--mode timestamps/full` を廃止し、`--with-ocr` フラグに置き換え
- デフォルト動作をタイムスタンプ抽出のみに変更（実態に合わせる）
- OCR解析（プレイヤー名・機体名・勝敗）は `--with-ocr` フラグで明示的に有効化する実験的機能に
- GitHub Actions ワークフローから不要になった `--mode timestamps` の指定を削除

## Test plan
- [ ] `python main.py --input <動画>` でタイムスタンプCSVが出力されること
- [ ] `python main.py --input <動画> --with-ocr` でOCR結果CSVが出力されること
- [ ] `python main.py --help` でヘルプが正しく表示されること

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)