### PR TITLE
feat: 解析失敗時に vsmobile-kgy API へ通知する

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -134,3 +134,16 @@ jobs:
               print(f"❌ 送信失敗 (HTTP {e.code}): {e.read().decode()}")
               sys.exit(1)
           EOF
+
+      - name: 失敗を vsmobile-kgy API に通知
+        if: failure()
+        env:
+          API_URL: ${{ secrets.VSMOBILE_FOR_KGY_API_URL }}
+          API_TOKEN: ${{ secrets.VSMOBILE_FOR_KGY_API_TOKEN }}
+          EVENT_ID: ${{ inputs.event_id }}
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer $API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"error\": \"GitHub Actions ワークフローが失敗しました\"}" \
+            "$API_URL/api/events/$EVENT_ID/notify_failure"


### PR DESCRIPTION
## Summary

- `analyze.yml` の末尾に `if: failure()` 条件付きの失敗通知ステップを追加
- 前のステップがいずれか失敗した場合のみ `POST /api/events/:id/notify_failure` を呼び出す
- 使用 Secrets: `VSMOBILE_FOR_KGY_API_URL`、`VSMOBILE_FOR_KGY_API_TOKEN`（登録済み）

## Test plan

- [ ] ワークフローを手動実行し、意図的にステップを失敗させて通知が届くことを確認

Closes #24