### PR TITLE
docs: README のバージョン情報に v1.1.0 を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ exvs2ib-replay-parser/
 
 ## バージョン情報
 
+### v1.1.0
+
+- GitHub Actions ワークフロー失敗時に vsmobile-kgy API へ通知する機能を追加
+
 ### v1.0.0
 
 - タイムスタンプ抽出をメイン機能として整理（`--with-ocr` なしがデフォルト）


### PR DESCRIPTION
## Summary
- README.md の「バージョン情報」セクションに v1.1.0 のエントリを追加
  - GitHub Actions ワークフロー失敗時に vsmobile-kgy API へ通知する機能を追加

## Test plan
- [ ] README.md の「バージョン情報」セクションに v1.1.0 が記載されていることを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)